### PR TITLE
Allow provisioning of renv libraries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Suggests:
     mockery,
     pkgdepends,
     remotes,
+    renv,
     testthat,
     withr
 Language: en-GB

--- a/R/configure.R
+++ b/R/configure.R
@@ -9,7 +9,7 @@
 ##'   a character vector of references (rather than reading from the
 ##'   file `pkgdepends.txt`) and `policy` which is passed through to
 ##'   [pkgdepends::new_pkg_installation_proposal].
-##' * method `auto` takes and argument `environment` which contains a
+##' * method `auto` takes an argument `environment` which contains a
 ##'   list of packages to install and source files to scan for
 ##'   dependencies.
 ##' * method `renv` takes no arguments.

--- a/R/configure.R
+++ b/R/configure.R
@@ -60,6 +60,8 @@ conan_configure <- function(method, ..., path_lib, path_bootstrap,
       assert_scalar_character(args$refs, "refs", call = rlang::current_env())
     }
     assert_scalar_character(args$policy, "policy", call = rlang::current_env())
+  } else if (method == "renv") {
+    valid_args <- NULL
   } else if (method == "auto") {
     valid_args <- NULL
   } else {
@@ -108,7 +110,9 @@ conan_configure <- function(method, ..., path_lib, path_bootstrap,
 
 
 detect_method <- function(path, call = NULL) {
-  if (file.exists(file.path(path, "provision.R"))) {
+  if (using_renv()) {
+    "renv"
+  } else if (file.exists(file.path(path, "provision.R"))) {
     "script"
   } else if (file.exists(file.path(path, "pkgdepends.txt"))) {
     "pkgdepends"

--- a/R/configure.R
+++ b/R/configure.R
@@ -9,11 +9,15 @@
 ##'   a character vector of references (rather than reading from the
 ##'   file `pkgdepends.txt`) and `policy` which is passed through to
 ##'   [pkgdepends::new_pkg_installation_proposal].
+##' * method `auto` takes and argument `environment` which contains a
+##'   list of packages to install and source files to scan for
+##'   dependencies.
+##' * method `renv` takes no arguments.
 ##'
 ##' @title Configuration for conan
 ##'
-##' @param method The method to use; currently "script" and
-##'   "pkgdepends" are supported.
+##' @param method The method to use; currently "script",
+##'   "pkgdepends", "auto" and "renv" are supported.
 ##'
 ##' @param ... Additional arguments, method specific. See Details.
 ##'

--- a/R/configure.R
+++ b/R/configure.R
@@ -110,7 +110,7 @@ conan_configure <- function(method, ..., path_lib, path_bootstrap,
 
 
 detect_method <- function(path, call = NULL) {
-  if (using_renv()) {
+  if (using_renv(path)) {
     "renv"
   } else if (file.exists(file.path(path, "provision.R"))) {
     "script"

--- a/R/renv.R
+++ b/R/renv.R
@@ -1,0 +1,10 @@
+using_renv <- function(path = getwd()) {
+  if (!requireNamespace("renv", quietly = TRUE)) {
+    return(FALSE)
+  }
+  project <- is.null(renv::project(default = NULL))
+  if (is.null(project)) {
+    return(FALSE)
+  }
+  fs::path_has_parent(path, project)
+}

--- a/R/renv.R
+++ b/R/renv.R
@@ -2,7 +2,7 @@ using_renv <- function(path = getwd()) {
   if (!requireNamespace("renv", quietly = TRUE)) {
     return(FALSE)
   }
-  project <- is.null(renv::project(default = NULL))
+  project <- renv::project(default = NULL)
   if (is.null(project)) {
     return(FALSE)
   }

--- a/R/run.R
+++ b/R/run.R
@@ -21,6 +21,21 @@ conan_run <- function(config, show_log = TRUE) {
   path_script <- file.path(path, "conan.R")
   path_log <- file.path(path, "log")
   conan_write(config, path_script)
+  if (config$method == "renv") {
+    ## This all plays quite poorly with callr because it does a great
+    ## job of setting libPaths for us, after renv has finished setting
+    ## up the libPaths, so we never end up with a loaded version!
+    ##
+    ## I've confirmed that we can disable autoload by setting one of
+    ## these:
+    ##
+    ## RENV_AUTOLOADER_ENABLED
+    ## RENV_ACTIVATE_PROJECT
+    ## RENV_CONFIG_AUTOLOADER_ENABLED
+    ##
+    ## To anything other than true/t/1 (case insensitive).
+    withr::local_envvar(RENV_AUTOLOADER_ENABLED = "FALSE")
+  }
   callr::rscript(path_script, stdout = path_log, stderr = path_log,
                  show = show_log)
   invisible()

--- a/inst/template/install_renv.R
+++ b/inst/template/install_renv.R
@@ -1,0 +1,30 @@
+local({
+  message("Bootstrapping from: {{path_bootstrap}}")
+  message("Installing into library: {{path_lib}}")
+  message(sprintf("Running in path: %s", getwd()))
+
+  ## We can rely here on RENV_ACTIVATE_PROJECT or RENV_AUTOLOADER_ENABLED
+  if (Sys.getenv("RENV_AUTOLOADER_ENABLED", "") != "FALSE") {
+    stop(
+      "Expected environment variable 'RENV_AUTOLOADER_ENABLED' to be 'FALSE'")
+  }
+
+  if (!requireNamespace("renv", "{{path_bootstrap}}")) {
+    stop("Failed to load 'renv' from the bootstrap library")
+  }
+
+  if ({{delete_first}}) {
+    message()
+    message("Deleting previous library; this will fail if packages are in use")
+    message("Then your running jobs may also fail.")
+    unlink("{{path_lib}}", recursive = TRUE)
+  }
+
+  dir.create("{{path_lib}}", showWarnings = FALSE, recursive = TRUE)
+  .libPaths(file.path(getwd(), "{{path_lib}}"))
+
+  ## We might want to pass through packages/exclude here later,
+  ## possibly also clean?
+  renv::restore(library = "{{path_lib}}",
+                prompt = FALSE)
+})

--- a/man/conan_configure.Rd
+++ b/man/conan_configure.Rd
@@ -51,7 +51,7 @@ name of the script to run, defaults to "provision.R"
 a character vector of references (rather than reading from the
 file \code{pkgdepends.txt}) and \code{policy} which is passed through to
 \link[pkgdepends:pkg_installation_proposal]{pkgdepends::new_pkg_installation_proposal}.
-\item method \code{auto} takes and argument \code{environment} which contains a
+\item method \code{auto} takes an argument \code{environment} which contains a
 list of packages to install and source files to scan for
 dependencies.
 \item method \code{renv} takes no arguments.

--- a/man/conan_configure.Rd
+++ b/man/conan_configure.Rd
@@ -14,8 +14,8 @@ conan_configure(
 )
 }
 \arguments{
-\item{method}{The method to use; currently "script" and
-"pkgdepends" are supported.}
+\item{method}{The method to use; currently "script",
+"pkgdepends", "auto" and "renv" are supported.}
 
 \item{...}{Additional arguments, method specific. See Details.}
 
@@ -51,5 +51,9 @@ name of the script to run, defaults to "provision.R"
 a character vector of references (rather than reading from the
 file \code{pkgdepends.txt}) and \code{policy} which is passed through to
 \link[pkgdepends:pkg_installation_proposal]{pkgdepends::new_pkg_installation_proposal}.
+\item method \code{auto} takes and argument \code{environment} which contains a
+list of packages to install and source files to scan for
+dependencies.
+\item method \code{renv} takes no arguments.
 }
 }

--- a/tests/testthat/test-configure.R
+++ b/tests/testthat/test-configure.R
@@ -115,6 +115,17 @@ test_that("prefer script over pkgdepends", {
 })
 
 
+test_that("prefer renv the most", {
+  path <- withr::local_tempdir()
+  mock_using_renv <- mockery::mock(TRUE, cycle = TRUE)
+  mockery::stub(detect_method, "using_renv", mock_using_renv)
+  expect_equal(detect_method(path), "renv")
+  file.create(file.path(path, "pkgdepends.txt"))
+  file.create(file.path(path, "provision.R"))
+  expect_equal(detect_method(path), "renv")
+})
+
+
 test_that("can fall back on automatic installation", {
   path <- withr::local_tempdir()
   env <- list(packages = c("apple", "banana"))

--- a/tests/testthat/test-renv.R
+++ b/tests/testthat/test-renv.R
@@ -1,0 +1,38 @@
+test_that("can't be using renv if not installed", {
+  mock_require_ns <- mockery::mock(FALSE)
+  mockery::stub(using_renv, "requireNamespace", mock_require_ns)
+  expect_false(using_renv())
+  mockery::expect_called(mock_require_ns, 1)
+  expect_equal(mockery::mock_args(mock_require_ns)[[1]],
+               list("renv", quietly = TRUE))
+})
+
+
+test_that("can't be using renv if project not defined", {
+  mock_project <- mockery::mock(NULL)
+  mockery::stub(using_renv, "renv::project", mock_project)
+  expect_false(using_renv())
+  mockery::expect_called(mock_project, 1)
+  expect_equal(mockery::mock_args(mock_project)[[1]],
+               list(default = NULL))
+})
+
+
+test_that("can't be using renv if project elsewhere to current path", {
+  path <- withr::local_tempfile()
+  mock_project <- mockery::mock(path)
+  mockery::stub(using_renv, "renv::project", mock_project)
+  expect_false(using_renv())
+  mockery::expect_called(mock_project, 1)
+  expect_equal(mockery::mock_args(mock_project)[[1]],
+               list(default = NULL))
+})
+
+
+test_that("accept project if it's in current or parent directory", {
+  path <- withr::local_tempfile()
+  mock_project <- mockery::mock(path, dirname(path))
+  mockery::stub(using_renv, "renv::project", mock_project)
+  expect_true(using_renv(path))
+  expect_true(using_renv(path))
+})

--- a/tests/testthat/test-zzz-run.R
+++ b/tests/testthat/test-zzz-run.R
@@ -33,3 +33,25 @@ test_that("can run an automatic installation", {
   withr::with_dir(path, conan_run(cfg, show_log = FALSE))
   expect_true(file.exists(file.path(path, "lib", "R6")))
 })
+
+
+test_that("can run an renv installation", {
+  path <- withr::local_tempdir()
+  writeLines("library(R6)", file.path(path, "code.R"))
+  res <- withr::with_dir(path, callr::r(function() {
+    renv::init()
+    install.packages("R6")
+    renv::snapshot()
+    list(pkgs = .packages(TRUE), libs = .libPaths())
+  }))
+
+  path_lib <- "lib"
+  path_bootstrap <- bootstrap_library("renv")
+  cfg <- conan_configure("renv", path = path, path_lib = path_lib,
+                         path_bootstrap = path_bootstrap,
+                         show_log = FALSE)
+  withr::with_dir(path, conan_run(cfg))
+
+  expect_true(file.exists(file.path(path, "lib", "R6")))
+  expect_true(file.exists(file.path(path, "lib", "renv")))
+})

--- a/tests/testthat/test-zzz-run.R
+++ b/tests/testthat/test-zzz-run.R
@@ -48,9 +48,8 @@ test_that("can run an renv installation", {
   path_lib <- "lib"
   path_bootstrap <- bootstrap_library("renv")
   cfg <- conan_configure("renv", path = path, path_lib = path_lib,
-                         path_bootstrap = path_bootstrap,
-                         show_log = FALSE)
-  withr::with_dir(path, conan_run(cfg))
+                         path_bootstrap = path_bootstrap)
+  withr::with_dir(path, conan_run(cfg, show_log = FALSE))
 
   expect_true(file.exists(file.path(path, "lib", "R6")))
   expect_true(file.exists(file.path(path, "lib", "renv")))


### PR DESCRIPTION
In the end, not as bad as it could have been I think:

* `renv::project()` can be used to detect if the user is currently using renv; this feels ok, but we could expand this to the presence of the lockfile later perhaps?
* If we set the environment variable `RENV_AUTOLOADER_ENABLED` to any non-truthy value then the autoloader does not run, which means it's easy to prevent multiple things trying to write to the library at once, and we can just run our provisioner once
