### PR TITLE
Combine install scripts

### DIFF
--- a/inst/template/install_pkgdepends.R
+++ b/inst/template/install_pkgdepends.R
@@ -1,52 +1,13 @@
+options(repos = {{repos}})
+
 local({
-  message("Bootstrapping from: {{path_bootstrap}}")
-  message("Installing into library: {{path_lib}}")
-  message(sprintf("Running in path: %s", getwd()))
-
-  ## TODO: we can work this out from pkgdepends and have it tell us;
-  ## all its (recursive) hard dependencies)
-  preload <- c("ps", "cli", "curl", "filelock", "pkgdepends", "pkgcache",
-               "processx", "lpSolve", "jsonlite", "withr", "desc", "zip",
-               "pkgbuild", "callr")
-  for (pkg in preload) {
-    if (!requireNamespace(pkg, "{{path_bootstrap}}")) {
-      stop(sprintf("Failed to load '%s' from the bootstrap library", pkg))
-    }
-  }
-
-  if ({{delete_first}}) {
-    message()
-    message("Deleting previous library; this will fail if packages are in use")
-    message("Then your running jobs may also fail.")
-    unlink("{{path_lib}}", recursive = TRUE)
-  }
-
-  dir.create("{{path_lib}}", showWarnings = FALSE, recursive = TRUE)
-  .libPaths(file.path(getwd(), "{{path_lib}}"))
-
-  message("Library paths:")
-  message(paste(sprintf("  - %s", .libPaths()), collapse = "\n"))
-
-  options(repos = {{repos}})
+  proposal <- pkgdepends::new_pkg_installation_proposal(
+    refs = {{refs}},
+    policy = "{{policy}}")
+  proposal$solve()
+  proposal$stop_for_solution_error()
+  proposal$show_solution()
+  proposal$download()
+  proposal$stop_for_download_error()
+  proposal$install()
 })
-
-message("Logs from pkgdepends follow:")
-message()
-message(strrep("-", 79))
-message()
-
-proposal <- pkgdepends::new_pkg_installation_proposal(
-  refs = {{refs}},
-  policy = "{{policy}}")
-proposal$solve()
-proposal$stop_for_solution_error()
-proposal$show_solution()
-proposal$download()
-proposal$stop_for_download_error()
-proposal$install()
-
-message()
-message(strrep("-", 79))
-
-# TODO: print a summary of package versions now available in the
-# library, go through all packages.

--- a/inst/template/install_renv.R
+++ b/inst/template/install_renv.R
@@ -1,30 +1,10 @@
-local({
-  message("Bootstrapping from: {{path_bootstrap}}")
-  message("Installing into library: {{path_lib}}")
-  message(sprintf("Running in path: %s", getwd()))
-
   ## We can rely here on RENV_ACTIVATE_PROJECT or RENV_AUTOLOADER_ENABLED
-  if (Sys.getenv("RENV_AUTOLOADER_ENABLED", "") != "FALSE") {
-    stop(
-      "Expected environment variable 'RENV_AUTOLOADER_ENABLED' to be 'FALSE'")
-  }
+if (Sys.getenv("RENV_AUTOLOADER_ENABLED", "") != "FALSE") {
+  stop(
+    "Expected environment variable 'RENV_AUTOLOADER_ENABLED' to be 'FALSE'")
+}
 
-  if (!requireNamespace("renv", "{{path_bootstrap}}")) {
-    stop("Failed to load 'renv' from the bootstrap library")
-  }
-
-  if ({{delete_first}}) {
-    message()
-    message("Deleting previous library; this will fail if packages are in use")
-    message("Then your running jobs may also fail.")
-    unlink("{{path_lib}}", recursive = TRUE)
-  }
-
-  dir.create("{{path_lib}}", showWarnings = FALSE, recursive = TRUE)
-  .libPaths(file.path(getwd(), "{{path_lib}}"))
-
-  ## We might want to pass through packages/exclude here later,
-  ## possibly also clean?
-  renv::restore(library = "{{path_lib}}",
-                prompt = FALSE)
-})
+## We might want to pass through packages/exclude here later,
+## possibly also clean?
+renv::restore(library = "{{path_lib}}",
+              prompt = FALSE)

--- a/inst/template/install_script.R
+++ b/inst/template/install_script.R
@@ -1,35 +1,7 @@
-local({
-  message("Bootstrapping from: {{path_bootstrap}}")
-  message("Installing into library: {{path_lib}}")
-  message(sprintf("Running in path: %s", getwd()))
-
-  if (!requireNamespace("remotes", "{{path_bootstrap}}")) {
-    msg <- paste("Failed to load 'remotes' from the bootstrap library.",
-                 "If you are using 'remotes::install_github()' etc, then",
-                 "your script will fail. However, you can always install",
-                 "'remotes' yourself within your script and try again")
-    message()
-    message(paste(strwrap(msg), collapse = "\n"))
-  }
-
-  if ({{delete_first}}) {
-    message()
-    message("Deleting previous library; this will fail if packages are in use")
-    message("Then your running jobs may also fail.")
-    unlink("{{path_lib}}", recursive = TRUE)
-  }
-
-  dir.create("{{path_lib}}", showWarnings = FALSE, recursive = TRUE)
-  .libPaths(file.path(getwd(), "{{path_lib}}"))
-
-  message("Library paths:")
-  message(paste(sprintf("  - %s", .libPaths()), collapse = "\n"))
-
-  ## We need a CRAN mirror set or nothing works. The user is free to
-  ## replace this with something else if they want within their script,
-  ## but this saves every script needing one.
-  options(repos = {{repos}})
-})
+## We need a CRAN mirror set or nothing works. The user is free to
+## replace this with something else if they want within their script,
+## but this saves every script needing one.
+options(repos = {{repos}})
 
 message("Logs from your installation script '{{script}}' follow:")
 message()
@@ -38,6 +10,3 @@ message()
 source("{{script}}", echo = TRUE, max.deparse.length = Inf)
 message()
 message(strrep("-", 79))
-
-# TODO: print a summary of package versions now available in the
-# library, go through all packages.

--- a/inst/template/wrapper.R
+++ b/inst/template/wrapper.R
@@ -1,0 +1,46 @@
+local({
+  ## This is the bit that will get the axe
+  message("Bootstrapping from: {{path_bootstrap}}")
+  message("Installing into library: {{path_lib}}")
+  message("Using method {{method}}")
+  message(sprintf("Running in path: %s", getwd()))
+
+  preload <- {{preload}}
+  for (pkg in preload) {
+    if (!requireNamespace(pkg, "{{path_bootstrap}}", quietly = TRUE)) {
+      if ("{{method}}" == "script") {
+        msg <- paste("Failed to load 'remotes' from the bootstrap library.",
+                     "If you are using 'remotes::install_github()' etc, then",
+                     "your script will fail. However, you can always install",
+                     "'remotes' yourself within your script and try again")
+        message()
+        message(paste(strwrap(msg), collapse = "\n"))
+      } else {
+        stop(sprintf("Failed to load '%s' from the bootstrap library", pkg))
+      }
+    }
+  }
+
+  if ({{delete_first}}) {
+    message()
+    message("Deleting previous library; this will fail if packages are in use")
+    message("Then your running jobs may also fail.")
+    unlink("{{path_lib}}", recursive = TRUE)
+  }
+
+  dir.create("{{path_lib}}", showWarnings = FALSE, recursive = TRUE)
+  .libPaths(file.path(getwd(), "{{path_lib}}"))
+
+  message("Library paths:")
+  message(paste(sprintf("  - %s", .libPaths()), collapse = "\n"))
+})
+
+message("Logs from {{what}} follow:")
+message()
+message(strrep("-", 79))
+message()
+
+{{implementation}}
+
+message()
+message(strrep("-", 79))

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -8,8 +8,11 @@ test_that("can write out script based on configuration", {
   expect_true(file.exists(dest))
 
   dat <- template_data(cfg)
-  expect_equal(setdiff(names(dat), names(cfg)), "repos")
+  expect_setequal(setdiff(names(dat), names(cfg)),
+                  c("repos", "preload", "what"))
   expect_equal(dat$repos, vector_to_str("https://cloud.r-project.org"))
+  expect_equal(dat$preload, vector_to_str("remotes"))
+  expect_equal(dat$what, "your installation script 'provision.R'")
 })
 
 
@@ -23,9 +26,11 @@ test_that("can write out pkgdepends script based on configuration", {
   expect_true(file.exists(dest))
 
   dat <- template_data(cfg)
-  expect_equal(setdiff(names(dat), names(cfg)), c("repos", "refs"))
+  expect_setequal(setdiff(names(dat), names(cfg)),
+                  c("repos", "refs", "preload", "what"))
   expect_equal(dat$repos, vector_to_str("https://cloud.r-project.org"))
   expect_equal(dat$refs, vector_to_str("foo"))
+  expect_equal(dat$what, "pkgdepends")
 })
 
 


### PR DESCRIPTION
This PR mops up some egregious duplication in the installation scripts. Once this is in place we can start doing more common things like display information about what changed, add the ascii art back, etc.