### PR TITLE
Support sending environment variables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
 Suggests:
     callr,
     mockery,
+    openssl,
     pkgdepends,
     remotes,
     renv,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: conan2
 Title: Conan the Librarian
-Version: 1.9.98
+Version: 1.9.99
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/configure.R
+++ b/R/configure.R
@@ -15,7 +15,7 @@
 ##' * method `renv` takes no arguments.
 ##'
 ##' Setting environment variables while running the installation comes
-##' uses the `envvars` argument; this system is designed to play well
+##' via the `envvars` argument; this system is designed to play well
 ##' with `hipercow`, though it does not require it.  We expect a
 ##' `data.frame` with columns `name`, `value` and (optionally)
 ##' `secret`.  If `secret` is given, it must be a logical value

--- a/R/configure.R
+++ b/R/configure.R
@@ -14,6 +14,18 @@
 ##'   dependencies.
 ##' * method `renv` takes no arguments.
 ##'
+##' Setting environment variables while running the installation comes
+##' uses the `envvars` argument; this system is designed to play well
+##' with `hipercow`, though it does not require it.  We expect a
+##' `data.frame` with columns `name`, `value` and (optionally)
+##' `secret`.  If `secret` is given, it must be a logical value
+##' indicating that `value` has been encrypted with an `rsa` public
+##' key.  If any `secret` is `TRUE`, then `envvvars` must also have an
+##' *attribute* `key` that contains the path to private rsa key to
+##' decrypt the secrets (i.e., `attr(envvars, "key")`).  If you use
+##' secret environment variables, then the `openssl` package must be
+##' present in conan's bootstrap.
+##'
 ##' @title Configuration for conan
 ##'
 ##' @param method The method to use; currently `script`,
@@ -46,12 +58,15 @@
 ##'   typically this is the same path is the root of the project,
 ##'   often as the working directory.
 ##'
+##' @param envvars Environment variables to set before running the
+##'   installation.  See Details for format.
+##'
 ##' @return A list with class `conan_config`. Do not modify
 ##'   this object.
 ##'
 ##' @export
 conan_configure <- function(method, ..., path_lib, path_bootstrap, cran = NULL,
-                            delete_first = FALSE, path = ".") {
+                            delete_first = FALSE, path = ".", envvars = NULL) {
   if (is.null(method)) {
     method <- detect_method(path, call = rlang::current_env())
     cli::cli_alert_success("Selected provisioning method '{method}'")
@@ -129,6 +144,7 @@ conan_configure <- function(method, ..., path_lib, path_bootstrap, cran = NULL,
   args$path_bootstrap <- assert_scalar_character(path_bootstrap)
   args$delete_first <- assert_scalar_logical(delete_first)
   args$cran <- cran
+  args$envvars <- check_envvars(envvars)
 
   class(args) <- "conan_config"
 
@@ -146,4 +162,30 @@ detect_method <- function(path, call = NULL) {
   } else {
     "auto"
   }
+}
+
+
+## Practically we won't see this from hipercow, but we might reuse
+## this in twinkle.  We probably need a nice way of creating one of
+## these too.
+check_envvars <- function(envvars) {
+  if (is.null(envvars)) {
+    return(NULL)
+  }
+  if (!inherits(envvars, "data.frame")) {
+    cli::cli_abort("Expected 'envvars' to be a data.frame")
+  }
+  msg <- setdiff(c("name", "value"), names(envvars))
+  if (length(msg) > 0) {
+    cli::cli_abort("Missing column{?s} from 'envvars': {squote(msg)}")
+  }
+  if (is.null(envvars$secret)) {
+    envvars$secret <- FALSE
+  }
+  key <- attr(envvars, "key", exact = TRUE)
+  if (any(envvars$secret) && is.null(key)) {
+    cli::cli_abort(
+      "Secret environment variables in 'envvars', but key not found")
+  }
+  envvars
 }

--- a/R/run.R
+++ b/R/run.R
@@ -108,7 +108,7 @@ generate_set_envvars <- function(envvars) {
     }
   }
   if (any(envvars$secret)) {
-    key <- sub("\\", "/", attr(envvars, "key", exact = TRUE), fixed = TRUE)
+    key <- gsub("\\", "/", attr(envvars, "key", exact = TRUE), fixed = TRUE)
     decrypt <- c(
       "decrypt <- function(value) {",
       "  rawToChar(openssl::rsa_decrypt(openssl::base64_decode(value),",

--- a/R/run.R
+++ b/R/run.R
@@ -73,9 +73,10 @@ template_data <- function(config) {
   ret$hash <- config$hash
   ret$args_str <- list_to_str(
     config[setdiff(names(config), c("method", "hash"))])
+  preload <- if (any(config$envvars$secret)) "openssl" else NULL
   if (config$method == "script") {
     ret$repos <- vector_to_str(config$cran)
-    ret$preload <- vector_to_str("remotes")
+    ret$preload <- vector_to_str(c("remotes", preload))
     ret$what <- sprintf("your installation script '%s'", config$script)
   } else if (config$method %in% c("pkgdepends", "auto")) {
     ret$repos <- vector_to_str(c(config$pkgdepends$repos, config$cran))
@@ -83,12 +84,40 @@ template_data <- function(config) {
     ret$preload <- vector_to_str(
       c("ps", "cli", "curl", "filelock", "pkgdepends", "pkgcache",
         "processx", "lpSolve", "jsonlite", "withr", "desc", "zip",
-        "pkgbuild", "callr"))
+        "pkgbuild", "callr", preload))
     ret$what <- "pkgdepends"
   } else if (config$method == "renv") {
-    ret$preload <- vector_to_str("renv")
+    ret$preload <- vector_to_str("renv", preload)
     ret$what <- "renv"
   }
   ret$conan_describe_definition <- deparse_fn("conan_describe", indent = 2)
+  ret$set_envvars <- generate_set_envvars(config$envvars)
   ret
+}
+
+
+generate_set_envvars <- function(envvars) {
+  if (is.null(envvars) || nrow(envvars) == 0) {
+    return("")
+  }
+  f <- function(name, value, secret) {
+    if (secret) {
+      sprintf('Sys.setenv("%s" = decrypt("%s"))', name, value)
+    } else {
+      sprintf('Sys.setenv("%s" = "%s")', name, value)
+    }
+  }
+  if (any(envvars$secret)) {
+    key <- attr(envvars, "key", exact = TRUE)
+    decrypt <- c(
+      "decrypt <- function(value) {",
+      "  rawToChar(openssl::rsa_decrypt(openssl::base64_decode(value),",
+      sprintf('                                 "%s"))', key),
+      "}")
+  } else {
+    decrypt <- NULL
+  }
+
+  ret <- Map(f, envvars$name, envvars$value, envvars$secret)
+  paste0("  ", c(decrypt, vcapply(ret, identity)), collapse = "\n")
 }

--- a/R/run.R
+++ b/R/run.R
@@ -87,7 +87,7 @@ template_data <- function(config) {
         "pkgbuild", "callr", preload))
     ret$what <- "pkgdepends"
   } else if (config$method == "renv") {
-    ret$preload <- vector_to_str("renv", preload)
+    ret$preload <- vector_to_str(c("renv", preload))
     ret$what <- "renv"
   }
   ret$conan_describe_definition <- deparse_fn("conan_describe", indent = 2)

--- a/R/run.R
+++ b/R/run.R
@@ -108,7 +108,7 @@ generate_set_envvars <- function(envvars) {
     }
   }
   if (any(envvars$secret)) {
-    key <- attr(envvars, "key", exact = TRUE)
+    key <- sub("\\", "/", attr(envvars, "key", exact = TRUE), fixed = TRUE)
     decrypt <- c(
       "decrypt <- function(value) {",
       "  rawToChar(openssl::rsa_decrypt(openssl::base64_decode(value),",

--- a/inst/template/wrapper.R
+++ b/inst/template/wrapper.R
@@ -25,6 +25,8 @@ local({
     }
   }
 
+{{set_envvars}}
+
   if ({{delete_first}}) {
     message()
     message("Deleting previous library; this will fail if packages are in use")

--- a/man/conan_configure.Rd
+++ b/man/conan_configure.Rd
@@ -11,7 +11,8 @@ conan_configure(
   path_bootstrap,
   cran = NULL,
   delete_first = FALSE,
-  path = "."
+  path = ".",
+  envvars = NULL
 )
 }
 \arguments{
@@ -43,6 +44,9 @@ into it?}
 \item{path}{Path to the root where you would run conan from;
 typically this is the same path is the root of the project,
 often as the working directory.}
+
+\item{envvars}{Environment variables to set before running the
+installation.  See Details for format.}
 }
 \value{
 A list with class \code{conan_config}. Do not modify
@@ -66,4 +70,16 @@ list of packages to install and source files to scan for
 dependencies.
 \item method \code{renv} takes no arguments.
 }
+
+Setting environment variables while running the installation comes
+uses the \code{envvars} argument; this system is designed to play well
+with \code{hipercow}, though it does not require it.  We expect a
+\code{data.frame} with columns \code{name}, \code{value} and (optionally)
+\code{secret}.  If \code{secret} is given, it must be a logical value
+indicating that \code{value} has been encrypted with an \code{rsa} public
+key.  If any \code{secret} is \code{TRUE}, then \code{envvvars} must also have an
+\emph{attribute} \code{key} that contains the path to private rsa key to
+decrypt the secrets (i.e., \code{attr(envvars, "key")}).  If you use
+secret environment variables, then the \code{openssl} package must be
+present in conan's bootstrap.
 }

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -10,7 +10,7 @@ test_that("can write out script based on configuration", {
   dat <- template_data(cfg)
   expect_setequal(setdiff(names(dat), names(cfg)),
                   c("repos", "preload", "what", "args_str",
-                    "conan_describe_definition"))
+                    "conan_describe_definition", "set_envvars"))
   expect_equal(dat$repos, vector_to_str("https://cloud.r-project.org"))
   expect_equal(dat$preload, vector_to_str("remotes"))
   expect_equal(dat$what, "your installation script 'provision.R'")
@@ -18,6 +18,7 @@ test_that("can write out script based on configuration", {
   expect_equal(dat$hash, cfg$hash)
   expect_equal(dat$args_str,
                list_to_str(cfg[setdiff(names(cfg), c("method", "hash"))]))
+  expect_equal(dat$set_envvars, "")
 })
 
 
@@ -34,7 +35,7 @@ test_that("can write out pkgdepends script based on configuration", {
   dat <- template_data(cfg)
   expect_setequal(setdiff(names(dat), names(cfg)),
                   c("repos", "refs", "preload", "what", "args_str",
-                    "conan_describe_definition"))
+                    "conan_describe_definition", "set_envvars"))
   expect_equal(dat$repos, vector_to_str("https://cran.example.com"))
   expect_equal(dat$refs, vector_to_str("foo"))
   expect_equal(dat$what, "pkgdepends")

--- a/tests/testthat/test-zzz-run.R
+++ b/tests/testthat/test-zzz-run.R
@@ -113,7 +113,7 @@ test_that("can run an renv installation", {
 })
 
 
-## This test requires a the TEST_CONAN_GITHUB_TOKEN to exist, and
+## This test requires the TEST_CONAN_GITHUB_TOKEN to exist, and
 ## installs a trivial private package with it; you need access to
 ## reside-ic/ to run this test.
 test_that("can install a private package", {

--- a/tests/testthat/test-zzz-run.R
+++ b/tests/testthat/test-zzz-run.R
@@ -111,3 +111,45 @@ test_that("can run an renv installation", {
   expect_s3_class(d$description, "conan_describe")
   expect_true(all(c("R6", "renv") %in% names(d$description$packages)))
 })
+
+
+## This test requires a the TEST_CONAN_GITHUB_TOKEN to exist, and
+## installs a trivial private package with it; you need access to
+## reside-ic/ to run this test.
+test_that("can install a private package", {
+  pat <- Sys.getenv("TEST_CONAN_GITHUB_TOKEN", NA)
+  if (is.na(pat)) {
+    testthat::skip("TEST_CONAN_GITHUB_TOKEN not found")
+  }
+  withr::local_envvar(GITHUB_TOKEN = NA, GITHUB_PAT = NA)
+
+  path <- withr::local_tempdir()
+  writeLines("reside-ic/secretsquirrel", file.path(path, "pkgdepends.txt"))
+  path_key <- withr::local_tempfile()
+  key <- openssl::rsa_keygen()
+  openssl::write_pem(key, path_key)
+  pub <- as.list(key)$pubkey
+  pat <- openssl::base64_encode(openssl::rsa_encrypt(charToRaw(pat), pub))
+  envvars <- data.frame(name = "GITHUB_TOKEN", value = pat, secret = TRUE)
+  attr(envvars, "key") <- path_key
+
+  path_lib <- "lib"
+  path_bootstrap <- bootstrap_library("pkgdepends")
+  cfg <- conan_configure(NULL, path = path, path_lib = path_lib,
+                         path_bootstrap = path_bootstrap, envvars = envvars)
+
+  withr::with_dir(path, conan_run(cfg, show_log = FALSE))
+
+  expect_true(file.exists(file.path(path, "lib", "secretsquirrel")))
+
+  expect_true(file.exists(file.path(path, "lib", ".conan")))
+  expect_length(dir(file.path(path, "lib", ".conan")), 1)
+  d <- readRDS(dir(file.path(path, "lib", ".conan"), full.names = TRUE))
+
+  expect_equal(d$method, "pkgdepends")
+  expect_equal(d$hash, cfg$hash)
+  expect_mapequal(d$args$pkgdepends,
+                  list(refs = "reside-ic/secretsquirrel", repos = NULL))
+  expect_s3_class(d$description, "conan_describe")
+  expect_true("secretsquirrel" %in% names(d$description$packages))
+})


### PR DESCRIPTION
This PR allows us to use a GITHUB pat (or other environment variable) within an installation.

To install a private repo, one must create a PAT with "repo" scope, which is quite a lot of power.  There's a test that uses one of these in the integration tests.

I've copied over the approach that hipercow uses for dealing with environment variables.  I think that will be ok in that we never expect that anyone will directly use conan, just us (via hipercow and eventually twinkle).