### PR TITLE
Don't warn on reading files that lack trailing newlines

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: conan2
 Title: Conan the Librarian
-Version: 1.9.100
+Version: 1.9.101
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/configure.R
+++ b/R/configure.R
@@ -123,7 +123,7 @@ conan_configure <- function(method, ..., path_lib, path_bootstrap, cran = NULL,
         cli::cli_abort(
           "Expected a file 'pkgdepends.txt' to exist at path '{path}'")
       }
-      refs <- readLines(path_pkgdepends)
+      refs <- read_lines(path_pkgdepends)
     } else {
       refs <- args$refs
     }

--- a/R/util.R
+++ b/R/util.R
@@ -18,8 +18,16 @@ conan_file <- function(path) {
 }
 
 
+read_lines <- function(path) {
+  ## never warn about trailing newlines.  Unfortunately this will also
+  ## not warn about embedded null's but that's rare and also usually
+  ## not a very helpful warning for users to see.
+  readLines(path, warn = FALSE)
+}
+
+
 read_string <- function(path) {
-  paste(readLines(path), collapse = "\n")
+  paste(read_lines(path), collapse = "\n")
 }
 
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -27,3 +27,11 @@ test_that("can convert numbers to ordinals", {
   expect_equal(ordinal(24), "24th")
   expect_equal(ordinal(43221), "43221st")
 })
+
+
+test_that("don't warn when reading from files without newlines", {
+  path <- withr::local_tempfile()
+  writeLines("hello", sep = "", path)
+  expect_warning(readLines(path))
+  expect_no_warning(read_lines(path))
+})


### PR DESCRIPTION
This confuses users, as it warns after everything has worked fine.